### PR TITLE
Refactor - cli_wallet `help` command outputs show mess

### DIFF
--- a/libraries/wallet/generate_api_documentation.pl.in
+++ b/libraries/wallet/generate_api_documentation.pl.in
@@ -44,8 +44,7 @@ for my $class (@{$doxydocs->{classes}})
       if ($member->{kind} eq 'function')
       {
         my @params = map { join(' ', cleanupDoxygenType($_->{type}), $_->{declaration_name}) } @{$member->{parameters}};
-        my $briefDescription = sprintf("%40s %s(%s)\n", cleanupDoxygenType($member->{type}), $member->{name}, join(', ', @params));
-        my $escapedBriefDescription = "\"" . escapeStringForC($briefDescription) . "\"";
+        my $briefIntro;
         my %paramInfo = map { $_->{declaration_name} => { type => $_->{type}} } @{$member->{parameters}};
         my $escapedDetailedDescription = "\"\"\n";
         if ($member->{detailed}->{doc})
@@ -54,8 +53,14 @@ for my $class (@{$doxydocs->{classes}})
           for my $line (split(/\n/, $docString))
           {
             $escapedDetailedDescription .=  "                \"" .  escapeStringForC($line . "\n") . "\"\n";
+            # take the first line of detailed doc as brief introduction
+            if ( ! defined $briefIntro) { 
+              $briefIntro = $line;
+            }
           }
         }
+        my $briefDescription = sprintf("%40s %s\n", $member->{name}, (defined($briefIntro) ? "- $briefIntro" : "") );
+        my $escapedBriefDescription = "\"" . escapeStringForC($briefDescription) . "\"";
         my $codeFragment = <<"END";
      {
         method_description this_method;

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -4123,6 +4123,8 @@ string wallet_api::help() const
 {
       std::vector<std::string> method_names = my->method_documentation.get_method_names();
       std::stringstream ss;
+	  
+      ss << "All available commands:\n";
       for (const std::string method_name : method_names)
       {
             try
@@ -4134,6 +4136,8 @@ string wallet_api::help() const
                   ss << method_name << " (no help available)\n";
             }
       }
+      ss << " (You can use `gethelp command` for single command usage)\n";
+	  
       return ss.str();
 }
 


### PR DESCRIPTION
when using the cli_wallet help command, its output are meaningless and not intuitive. The suggestive outputs are to list all avialable commands and their brief introductions.

This pr is created to refactor cli_wallet 'help' command output:
1. display all available commands;
2. take the first line of doxygen detailed doc string as command brief introduction.

(please note: doxygen must be installed when compiling to make it work properly)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cocos-bcx/cocos-mainnet/24)
<!-- Reviewable:end -->
