### PR TITLE
Nft trade asset with lock support

### DIFF
--- a/libraries/chain/contract_evaluator.cpp
+++ b/libraries/chain/contract_evaluator.cpp
@@ -61,7 +61,8 @@ void_result revise_contract_evaluator::do_evaluate(const operation_type &o)
         auto &contract = o.contract_id(d);
         auto &contract_owner = contract.owner(d);
         FC_ASSERT(!contract.is_release," The current contract is  release version cannot be change ");
-        FC_ASSERT(contract_owner.asset_locked.contract_lock_details.find(o.contract_id) == contract_owner.asset_locked.contract_lock_details.end());
+        FC_ASSERT(contract_owner.asset_locked.contract_lock_details.find(o.contract_id) == contract_owner.asset_locked.contract_lock_details.end(), "You can't modify the contract with some token locked within.");
+        FC_ASSERT(contract_owner.asset_locked.contract_nft_lock_details.find(o.contract_id) == contract_owner.asset_locked.contract_nft_lock_details.end(), "You can't modify the contract with some NFT asset locked within.");
         FC_ASSERT(contract_owner.get_id() == o.reviser, "You do not have the authority to modify the contract,the contract owner is ${owner}",
                   ("owner", contract_owner.get_id()));
         return void_result();

--- a/libraries/chain/contract_nht_handle.cpp
+++ b/libraries/chain/contract_nht_handle.cpp
@@ -164,16 +164,7 @@ void register_scheduler::transfer_nht(account_id_type from, account_id_type acco
 {
     try
     {
-        // 验证转账方是否为资产所有人
-        FC_ASSERT(token.nh_asset_owner == from, "You'e not the NFT asset's owner, so you can't transfer it, NFT asset:${token}.", ("token", token));
-        // Verify beneficiary
-        FC_ASSERT(token.nh_asset_owner != account_to, "The beneficiary is already the asset's owner, NFT asset:${token}.", ("token", token));
-        // Verify dealership rights
-        bool dealership_transfer_ok = (token.nh_asset_owner == token.dealership) || (token.dealership == account_to);
-        FC_ASSERT(dealership_transfer_ok, "Neither the NFT asset's owner nor the beneficiary have the dealership rights, NFT asset:${token}", ("token", token));
-        // Verify active rights
-        bool active_transfer_ok = (token.nh_asset_owner == token.nh_asset_active) || (token.nh_asset_active == account_to);
-        FC_ASSERT(active_transfer_ok, "Neither the NFT asset's owner nor the beneficiary have the active rights, NFT asset:${token}", ("token", token));
+        nft::transfer_assert(from, account_to, token);
 
         db.modify(token, [&](nh_asset_object &g) {
             g.nh_asset_owner = account_to;

--- a/libraries/chain/contract_register_function.cpp
+++ b/libraries/chain/contract_register_function.cpp
@@ -495,6 +495,16 @@ void lua_scheduler::chain_function_bind()
                                                                            [](register_scheduler &fc_register, string token_hash_or_id, bool lock_or_unlock = true) {
                 auto& token = fc_register.get_nh_asset(token_hash_or_id);
                 fc_register.adjust_lock_nft_asset(token, lock_or_unlock); });
+    registerFunction<register_scheduler, void(string, string, bool)>("transfer_nft_ownership_from_owner",
+                                                                     [](register_scheduler &fc_register, string to, string token_hash_or_id, bool enable_logger = false) {
+                auto& token =fc_register.get_nh_asset(token_hash_or_id);
+                auto& account_to = fc_register.get_account(to).id;
+                fc_register.transfer_nft_ownership(fc_register.contract.owner, account_to, token,enable_logger); });
+    registerFunction<register_scheduler, void(string, string, bool)>("transfer_nft_ownership_from_caller",
+                                                                     [](register_scheduler &fc_register, string to, string token_hash_or_id, bool enable_logger = false) {
+                auto& token =fc_register.get_nh_asset(token_hash_or_id);
+                auto& account_to = fc_register.get_account(to).id;;
+                fc_register.transfer_nft_ownership(fc_register.caller, account_to, token,enable_logger); });
 }
 
 void contract_object::register_function(lua_scheduler &context, register_scheduler *fc_register, contract_base_info *base_info)const

--- a/libraries/chain/contract_register_function.cpp
+++ b/libraries/chain/contract_register_function.cpp
@@ -482,7 +482,6 @@ void lua_scheduler::chain_function_bind()
                 auto& parent =fc_register.get_nh_asset(parent_token_hash_or_id);
                 auto& child =fc_register.get_nh_asset(child_token_hash_or_id);
                 fc_register.relate_nh_asset(fc_register.caller, parent, child, relate, enable_logger); });
-
     registerFunction<register_scheduler, string(string, string, string, bool, bool)>("create_nft_asset",
                                                                            [](register_scheduler &fc_register, string owner_id, string world_view, string base_describe, bool dealership_to_contract = false, bool enable_logger = false) {
                 auto& owner = fc_register.get_account(owner_id).id;
@@ -492,6 +491,10 @@ void lua_scheduler::chain_function_bind()
                     return fc_register.create_nft_asset(owner, dealer, world_view, base_describe, enable_logger);
                 }
                 return fc_register.create_nft_asset(owner, owner, world_view, base_describe, enable_logger); });
+    registerFunction<register_scheduler, void(string, bool)>("adjust_lock_nft_asset",
+                                                                           [](register_scheduler &fc_register, string token_hash_or_id, bool lock_or_unlock = true) {
+                auto& token = fc_register.get_nh_asset(token_hash_or_id);
+                fc_register.adjust_lock_nft_asset(token, lock_or_unlock); });
 }
 
 void contract_object::register_function(lua_scheduler &context, register_scheduler *fc_register, contract_base_info *base_info)const

--- a/libraries/chain/contract_register_function.cpp
+++ b/libraries/chain/contract_register_function.cpp
@@ -482,6 +482,16 @@ void lua_scheduler::chain_function_bind()
                 auto& parent =fc_register.get_nh_asset(parent_token_hash_or_id);
                 auto& child =fc_register.get_nh_asset(child_token_hash_or_id);
                 fc_register.relate_nh_asset(fc_register.caller, parent, child, relate, enable_logger); });
+
+    registerFunction<register_scheduler, string(string, string, string, bool, bool)>("create_nft_asset",
+                                                                           [](register_scheduler &fc_register, string owner_id, string world_view, string base_describe, bool dealership_to_contract = false, bool enable_logger = false) {
+                auto& owner = fc_register.get_account(owner_id).id;
+
+                if (dealership_to_contract) {
+                    auto& dealer = fc_register.contract.owner;
+                    return fc_register.create_nft_asset(owner, dealer, world_view, base_describe, enable_logger);
+                }
+                return fc_register.create_nft_asset(owner, owner, world_view, base_describe, enable_logger); });
 }
 
 void contract_object::register_function(lua_scheduler &context, register_scheduler *fc_register, contract_base_info *base_info)const

--- a/libraries/chain/include/graphene/chain/contract_function_register_scheduler.hpp
+++ b/libraries/chain/include/graphene/chain/contract_function_register_scheduler.hpp
@@ -70,6 +70,8 @@ struct register_scheduler
     // relate parent nh asset and child nh asset
     void relate_nh_asset(account_id_type nht_creator, const nh_asset_object &parent_nh_asset, const nh_asset_object &child_nh_asset, bool relate, bool enable_logger=false);
 
+    // NFT relative methods
+    string create_nft_asset(account_id_type owner_id, account_id_type dealer_id, string world_view, string base_describe, bool enable_logger);
 
     void update_collateral_for_gas(string to, int64_t amount);
     lua_map get_contract_public_data(string name_or_id);

--- a/libraries/chain/include/graphene/chain/contract_function_register_scheduler.hpp
+++ b/libraries/chain/include/graphene/chain/contract_function_register_scheduler.hpp
@@ -73,6 +73,7 @@ struct register_scheduler
     // NFT relative methods
     string create_nft_asset(account_id_type owner_id, account_id_type dealer_id, string world_view, string base_describe, bool enable_logger);
     void adjust_lock_nft_asset(const nh_asset_object &token, bool lock_or_unlock=true);
+    void transfer_nft_ownership(account_id_type from, account_id_type account_to, const nh_asset_object &token, bool enable_logger=false);
 
     void update_collateral_for_gas(string to, int64_t amount);
     lua_map get_contract_public_data(string name_or_id);

--- a/libraries/chain/include/graphene/chain/contract_function_register_scheduler.hpp
+++ b/libraries/chain/include/graphene/chain/contract_function_register_scheduler.hpp
@@ -72,6 +72,7 @@ struct register_scheduler
 
     // NFT relative methods
     string create_nft_asset(account_id_type owner_id, account_id_type dealer_id, string world_view, string base_describe, bool enable_logger);
+    void adjust_lock_nft_asset(const nh_asset_object &token, bool lock_or_unlock=true);
 
     void update_collateral_for_gas(string to, int64_t amount);
     lua_map get_contract_public_data(string name_or_id);

--- a/libraries/chain/include/graphene/chain/nh_asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/nh_asset_object.hpp
@@ -38,6 +38,10 @@ enum class nh_asset_lease_limit_type
    white_list = 1
 };
 
+namespace nft {
+    void transfer_assert( const account_id_type& from, const account_id_type& to, const nh_asset_object& token);
+} // namespace nft
+
 class nh_asset_object : public graphene::db::abstract_object<nh_asset_object>
 {
 

--- a/libraries/chain/include/graphene/chain/nh_asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/nh_asset_object.hpp
@@ -60,6 +60,8 @@ class nh_asset_object : public graphene::db::abstract_object<nh_asset_object>
 	vector<contract_id_type> limit_list;
 	nh_asset_lease_limit_type limit_type = nh_asset_lease_limit_type::black_list;
 
+	nh_asset_id_type get_id() const { return id; }
+
     nh_hash_type get_base_describe_hash() const
     {
         nh_hash_type result(nh_hash);

--- a/libraries/chain/include/graphene/chain/nh_asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/nh_asset_object.hpp
@@ -39,7 +39,8 @@ enum class nh_asset_lease_limit_type
 };
 
 namespace nft {
-    void transfer_assert( const account_id_type& from, const account_id_type& to, const nh_asset_object& token);
+    void assert_asset_transfer( const account_id_type& from, const account_id_type& to, const nh_asset_object& token);
+    void assert_asset_unlocked( const account_object& owner, const nh_asset_object& token );
 } // namespace nft
 
 class nh_asset_object : public graphene::db::abstract_object<nh_asset_object>

--- a/libraries/chain/include/graphene/chain/protocol/account.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/account.hpp
@@ -50,6 +50,7 @@ struct account_options
   //flat_set<std::string>   extensions;
   void validate() const;
 };
+
 struct asset_locked_object
 {
   map<asset_id_type,share_type> locked_total;
@@ -58,7 +59,11 @@ struct asset_locked_object
   optional<asset> witness_freeze;
   optional<asset> vote_for_committee;
   optional<asset> vote_for_witness;
-  };
+
+  // for NFT asset lock
+  map<contract_id_type,vector<nh_asset_id_type>> contract_nft_lock_details;
+};
+
 /**
     *  @ingroup operations
     */

--- a/libraries/chain/include/graphene/chain/protocol/account.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/account.hpp
@@ -62,6 +62,7 @@ struct asset_locked_object
 
   // for NFT asset lock
   map<contract_id_type,vector<nh_asset_id_type>> contract_nft_lock_details;
+  vector<nh_asset_id_type> nft_locked;
 };
 
 /**

--- a/libraries/chain/nh_asset_order_evaluator.cpp
+++ b/libraries/chain/nh_asset_order_evaluator.cpp
@@ -46,7 +46,8 @@ void_result create_nh_asset_order_evaluator::do_evaluate(const create_nh_asset_o
    FC_ASSERT( d.find_object(o.nh_asset) , "Could not find nh asset matching ${nh_asset}", ("nh_asset", o.nh_asset));
    FC_ASSERT( o.nh_asset(d).nh_asset_owner == o.seller , "You’re not the item's owner." );
 
-   nft::transfer_assert(o.seller, account_id_type(), nft);
+   // Assert asset transfer
+   nft::assert_asset_transfer(o.seller, account_id_type(), nft);
 
    FC_ASSERT( o.expiration >= d.head_block_time(), "Order has already expired on creation" );
    FC_ASSERT( o.expiration <= d.head_block_time() + d.get_global_properties().parameters.maximum_nh_asset_order_expiration, "the expiration must less than the maximun expiration." );
@@ -54,6 +55,9 @@ void_result create_nh_asset_order_evaluator::do_evaluate(const create_nh_asset_o
    const account_object& from_account    = o.seller(d);
    const account_object& to_account      = o.otcaccount(d);
    const asset_object&   asset_type      = o.pending_orders_fee.asset_id(d);
+
+   // Assert asset unlocked
+   nft::assert_asset_unlocked(from_account, nft);
 
    try {
 

--- a/libraries/chain/nh_asset_order_evaluator.cpp
+++ b/libraries/chain/nh_asset_order_evaluator.cpp
@@ -41,8 +41,12 @@ namespace graphene { namespace chain {
 void_result create_nh_asset_order_evaluator::do_evaluate(const create_nh_asset_order_operation& o)
 {
    database& d = db();
+   auto& nft = o.nh_asset(d);
+
    FC_ASSERT( d.find_object(o.nh_asset) , "Could not find nh asset matching ${nh_asset}", ("nh_asset", o.nh_asset));
    FC_ASSERT( o.nh_asset(d).nh_asset_owner == o.seller , "You’re not the item's owner." );
+
+   nft::transfer_assert(o.seller, account_id_type(), nft);
 
    FC_ASSERT( o.expiration >= d.head_block_time(), "Order has already expired on creation" );
    FC_ASSERT( o.expiration <= d.head_block_time() + d.get_global_properties().parameters.maximum_nh_asset_order_expiration, "the expiration must less than the maximun expiration." );


### PR DESCRIPTION
1. add dealership delegate support for contract;
2. add NFT asset lock support by contract;
3. add restriction for locked NFT assets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cocos-bcx/cocos-mainnet/95)
<!-- Reviewable:end -->
