### PR TITLE
Fix table traversal method's radom enumeration problem

### DIFF
--- a/libraries/lua-gph/lib/src/lstate.cpp
+++ b/libraries/lua-gph/lib/src/lstate.cpp
@@ -45,7 +45,7 @@
 */
 #if !defined(luai_makeseed)
 #include <time.h>
-#define luai_makeseed()		cast(unsigned int, time(NULL))
+#define luai_makeseed()		cast(unsigned int, 0)
 #endif
 
 

--- a/libraries/lua-gph/lib/src/lstring.cpp
+++ b/libraries/lua-gph/lib/src/lstring.cpp
@@ -30,7 +30,7 @@
 ** compute its hash
 */
 #if !defined(LUAI_HASHLIMIT)
-#define LUAI_HASHLIMIT		5
+#define LUAI_HASHLIMIT		0
 #endif
 
 
@@ -47,7 +47,7 @@ int luaS_eqlngstr (TString *a, TString *b) {
 
 
 unsigned int luaS_hash (const char *str, size_t l, unsigned int seed) {
-  unsigned int h = seed ^ cast(unsigned int, l);
+  unsigned int h = cast(unsigned int, l);
   size_t step = (l >> LUAI_HASHLIMIT) + 1;
   for (; l >= step; l -= step)
     h ^= ((h<<5) + (h>>2) + cast_byte(str[l - 1]));

--- a/libraries/lua-gph/lib/src/ltable.cpp
+++ b/libraries/lua-gph/lib/src/ltable.cpp
@@ -200,6 +200,12 @@ int luaH_next (lua_State *L, Table *t, StkId key) {
     }
   }
   for (i -= t->sizearray; cast_int(i) < sizenode(t); i++) {  /* hash part */
+    /*check table key type, only integer, string available.
+    * but the code below only passed the invalid key types
+    * lua developer maynot get any info about this rule
+    * recommend using lua_error method instead. */
+    if (!ttisstring(gkey(gnode(t, i))) && !ttisinteger(gkey(gnode(t, i))))continue;
+    
     if (!ttisnil(gval(gnode(t, i)))) {  /* a non-nil value? */
       setobj2s(L, key, gkey(gnode(t, i)));
       setobj2s(L, key+1, gval(gnode(t, i)));


### PR DESCRIPTION
Refer to the designs about table traversal in lua 5.1 ver, and add a variable filter for 
enumerate functions.
this may solving the traversal or enumeration problems that result's order changes every different time .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cocos-bcx/cocos-mainnet/121)
<!-- Reviewable:end -->
