### PR TITLE
Bugfix contract for testnet

### DIFF
--- a/libraries/chain/contract_evaluator.cpp
+++ b/libraries/chain/contract_evaluator.cpp
@@ -1,5 +1,6 @@
 #include <graphene/chain/contract_evaluator.hpp>
 #include <graphene/chain/database.hpp>
+#include <lua_extern.hpp>
 
 namespace graphene
 {
@@ -12,9 +13,15 @@ uint64_t contract_max_data_size = 2 * 1024 * 1024 * 1024;
 
 void_result contract_create_evaluator::do_evaluate(const operation_type &o)
 {
-
-    return void_result(); //TODO: add verification in future
+    try
+    {
+        database &d = db();
+        lua_settop (d.get_luaVM().mState, 0);
+        return void_result(); //TODO: add verification in future
+    }
+    FC_CAPTURE_AND_RETHROW((o))
 }
+
 object_id_result contract_create_evaluator::do_apply(const operation_type &o)
 {
     try
@@ -94,9 +101,11 @@ void_result revise_contract_evaluator::do_evaluate(const operation_type &o)
         auto &contract_owner = contract.owner(d);
         FC_ASSERT(!contract.is_release," The current contract is  release version cannot be change ");
         FC_ASSERT(contract_owner.asset_locked.contract_lock_details.find(o.contract_id) == contract_owner.asset_locked.contract_lock_details.end(), "You can't modify the contract with some token locked within.");
-        FC_ASSERT(contract_owner.asset_locked.contract_nft_lock_details.find(o.contract_id) == contract_owner.asset_locked.contract_nft_lock_details.end(), "You can't modify the contract with some NFT asset locked within.");
+	FC_ASSERT((contract_owner.asset_locked.contract_nft_lock_details.find(o.contract_id) == contract_owner.asset_locked.contract_nft_lock_details.end() || contract_owner.asset_locked.contract_nft_lock_details.find(o.contract_id)->second.size() == 0), "You can't modify the contract with some NFT asset locked within.");
         FC_ASSERT(contract_owner.get_id() == o.reviser, "You do not have the authority to modify the contract,the contract owner is ${owner}",
                   ("owner", contract_owner.get_id()));
+
+        lua_settop (d.get_luaVM().mState, 0);
         return void_result();
     }
     FC_CAPTURE_AND_RETHROW((o))
@@ -130,6 +139,8 @@ void_result call_contract_function_evaluator::do_evaluate(const operation_type &
         this->op = &o;
         FC_ASSERT(o.contract_id!=contract_id_type());
         evaluate_contract_authority(o.contract_id, trx_state->sigkeys);
+        database &d = db();
+        lua_settop (d.get_luaVM().mState, 0);
         return void_result();
     }
     FC_CAPTURE_AND_RETHROW((o))

--- a/libraries/chain/contract_register_function.cpp
+++ b/libraries/chain/contract_register_function.cpp
@@ -93,7 +93,8 @@ void register_scheduler::invoke_contract_function(string contract_id_or_name, st
         state.sigkeys = sigkeys;
         evaluator.trx_state = &state;
         evaluator.evaluate_contract_authority(contract_id, state.sigkeys);
-        optional<contract_result> _contract_result;
+        //optional<contract_result> _contract_result;
+        contract_result _contract_result;
         if (trx_state->run_mode == transaction_apply_mode::apply_block_mode)
         {
             for (auto contract_afd = apply_result.contract_affecteds.begin(); contract_afd != apply_result.contract_affecteds.end(); contract_afd++)
@@ -111,7 +112,8 @@ void register_scheduler::invoke_contract_function(string contract_id_or_name, st
             _contract_result = contract_result();
         }
         auto current_contract_name = context.readVariable<string>("current_contract");
-        auto ret = evaluator.apply(caller, this->contract.id,function_name, value_list, _contract_result, sigkeys);
+        auto ocr = optional<contract_result>(_contract_result);
+        auto ret = evaluator.apply(caller, this->contract.id,function_name, value_list, ocr, sigkeys);
         context.writeVariable("current_contract", current_contract_name);
         if (ret.existed_pv)
             result.existed_pv = true;
@@ -315,6 +317,7 @@ static int get_account_contract_data(lua_State *L)
 }
 static int import_contract(lua_State *L)
 {
+    const contract_object* temp_contract=nullptr;
     try
     {
         lua_scheduler context(L);
@@ -322,38 +325,50 @@ static int import_contract(lua_State *L)
         auto name_or_id = lua_scheduler::readTopAndPop<string>(L, -1);
         auto current_contract_name = context.readVariable<string>("current_contract");
         auto chainhelper = context.readVariable<register_scheduler *>(current_contract_name, "chainhelper");
-        auto &temp_contract = chainhelper->get_contract(name_or_id);
-        auto &temp_contract_code=temp_contract.lua_code_b_id(chainhelper->db);
+        //auto &temp_contract = chainhelper->get_contract(name_or_id);
+        temp_contract = &chainhelper->get_contract(name_or_id);
+        auto &temp_contract_code=temp_contract->lua_code_b_id(chainhelper->db);
         auto cbi=context.readVariable<contract_base_info *>(current_contract_name, "contract_base_info");
         auto &baseENV = contract_bin_code_id_type(0)(chainhelper->db);
-        FC_ASSERT(lua_getglobal(context.mState, temp_contract.name.c_str())==LUA_TNIL);
-        context.new_sandbox(temp_contract.name,baseENV.lua_code_b.data(),baseENV.lua_code_b.size());
-        temp_contract.register_function(context,chainhelper, cbi);
+        FC_ASSERT(lua_getglobal(context.mState, temp_contract->name.c_str())==LUA_TNIL);
+        context.new_sandbox(temp_contract->name,baseENV.lua_code_b.data(),baseENV.lua_code_b.size());
+        temp_contract->register_function(context,chainhelper, cbi);
         FC_ASSERT(lua_getglobal(context.mState, current_contract_name.c_str()) == LUA_TTABLE);
-        if (lua_getfield(context.mState, -1, temp_contract.name.c_str()) == LUA_TTABLE)
+        if (lua_getfield(context.mState, -1, temp_contract->name.c_str()) == LUA_TTABLE)
             return 1;
         lua_pop(context.mState, 1);
-        lua_getglobal(context.mState, temp_contract.name.c_str());
-        lua_setfield(context.mState, -2, temp_contract.name.c_str());
+        lua_getglobal(context.mState, temp_contract->name.c_str());
+        lua_setfield(context.mState, -2, temp_contract->name.c_str());
         lua_pushnil(context.mState);
-        lua_setglobal(context.mState,temp_contract.name.c_str());
-        luaL_loadbuffer(context.mState, temp_contract_code.lua_code_b.data(), temp_contract_code.lua_code_b.size(), temp_contract.name.data()); //  lua加载脚本之后会返回一个函数(即此时栈顶的chunk块)，lua_pcall将默认调用此块
+        lua_setglobal(context.mState,temp_contract->name.c_str());
+        luaL_loadbuffer(context.mState, temp_contract_code.lua_code_b.data(), temp_contract_code.lua_code_b.size(), temp_contract->name.data()); //  lua加载脚本之后会返回一个函数(即此时栈顶的chunk块)，lua_pcall将默认调用此块
         lua_getglobal(context.mState, current_contract_name.c_str());
-        lua_getfield(context.mState, -1, temp_contract.name.c_str()); //想要使用的_ENV备用空间
+        lua_getfield(context.mState, -1, temp_contract->name.c_str()); //想要使用的_ENV备用空间
         lua_setupvalue(context.mState, -3, 1);                        //将栈顶变量赋值给栈顶第二个函数的第一个upvalue(当前第二个函数为load返回的函数，第一个upvalue为_ENV),注：upvalue:函数的外部引用变量
         lua_pop(context.mState, 1);
-        FC_ASSERT(lua_pcall(context.mState, 0, 0, 0) == 0, "import_contract ${contract}", ("contract", temp_contract.name));
+        FC_ASSERT(lua_pcall(context.mState, 0, 0, 0) == 0, "import_contract ${contract}", ("contract", temp_contract->name));
         lua_getglobal(context.mState, current_contract_name.c_str());
-        lua_getfield(context.mState, -1, temp_contract.name.c_str());
+        lua_getfield(context.mState, -1, temp_contract->name.c_str());
         return 1;
     }
     catch (fc::exception e)
     {
+        if(temp_contract)
+        {
+           lua_pushnil(L);
+           lua_setglobal(L,temp_contract->name.c_str()); 
+        }
+
         wdump((e.to_detail_string()));
         LUA_C_ERR_THROW(L, e.to_string());
     }
     catch (std::runtime_error e)
     {   
+        if(temp_contract)
+        {
+           lua_pushnil(L);
+           lua_setglobal(L,temp_contract->name.c_str()); 
+        }
         wdump((e.what()));
         LUA_C_ERR_THROW(L, e.what());
     }

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -165,10 +165,19 @@ void database::reindex(fc::path data_dir,int roll_back_at_height)
         ilog("reindexing blockchain");
         auto start = fc::time_point::now();
         auto last_block_num = last_block->block_num();
+        auto _last_block_num = last_block_num;
 
-        if(roll_back_at_height > 0)
+        if(roll_back_at_height > 0 && roll_back_at_height <= last_block_num)
+        {
             last_block_num = roll_back_at_height;
-            
+            for(int re_idx = _last_block_num; re_idx > roll_back_at_height; re_idx--)
+            {
+                fc::optional<block_id_type> last_id = _block_id_to_block.last_id();
+                ilog("remove block =>> ${block_num}:${block_id}",("block_num", re_idx)("block_id", *last_id));
+                _block_id_to_block.remove(*last_id);
+            }
+        }
+
         uint32_t undo_point = last_block_num < 50 ? 0 : last_block_num - 50;
 
         ilog("Replaying blocks, starting at ${next}...", ("next", head_block_num() + 1));

--- a/libraries/chain/evaluator.cpp
+++ b/libraries/chain/evaluator.cpp
@@ -129,7 +129,14 @@ operation_result generic_evaluator::start_evaluate(transaction_evaluation_state 
         auto &temp_result = ((processed_transaction *)trx_state->_trx)->operation_results[db().get_current_op_index()];
         if (temp_result.which() == operation_result::tag<error_result>::value)
           throw result;
-        FC_ASSERT(result.get<contract_result>().contract_affecteds == temp_result.get<contract_result>().contract_affecteds);
+        auto &res1 = result.get<contract_result>().contract_affecteds;
+        auto &res2 = temp_result.get<contract_result>().contract_affecteds;
+        if (res1 != res2) {
+          elog(">>>>>> compare contract result - run result != trx result !!!!!!");
+          edump((res1)(res2));
+        }
+        FC_ASSERT(res1 == res2);
+        //FC_ASSERT(result.get<contract_result>().contract_affecteds == temp_result.get<contract_result>().contract_affecteds);
         result = temp_result;
         static_cast<graphene::chain::call_contract_function_evaluator *>(this)->pay_fee_for_result(result.get<contract_result>());
         FC_ASSERT(core_fee_paid.value < db().get_global_properties().parameters.current_fees->maximun_handling_fee);

--- a/libraries/chain/include/graphene/chain/protocol/account.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/account.hpp
@@ -293,7 +293,7 @@ struct account_authentication_operation : public base_operation
 FC_REFLECT(graphene::chain::account_options, (memo_key)(votes)(extensions))
 FC_REFLECT(graphene::chain::account_authentication_operation::fee_parameters_type, (fee))
 FC_REFLECT(graphene::chain::account_authentication_operation, (account_id)(data)(extensions))
-FC_REFLECT(graphene::chain::asset_locked_object, (locked_total)(contract_lock_details)(committee_freeze)(witness_freeze)(vote_for_committee)(vote_for_witness))
+FC_REFLECT(graphene::chain::asset_locked_object, (locked_total)(contract_lock_details)(committee_freeze)(witness_freeze)(vote_for_committee)(vote_for_witness)(contract_nft_lock_details)(nft_locked))
 /*
 FC_REFLECT_ENUM(graphene::chain::account_whitelist_operation::account_listing,
                 (no_listing)(white_listed)(black_listed)(white_and_black_listed))

--- a/libraries/chain/include/graphene/chain/protocol/lua_scheduler.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/lua_scheduler.hpp
@@ -134,6 +134,8 @@ public:
             luaL_openlibs(mState);
             chain_function_bind();
         }
+
+        lua_checkstack(mState, 1000);
     }
 
     void chain_function_bind();

--- a/libraries/lua-gph/lib/src/lstate.cpp
+++ b/libraries/lua-gph/lib/src/lstate.cpp
@@ -45,7 +45,7 @@
 */
 #if !defined(luai_makeseed)
 #include <time.h>
-#define luai_makeseed()		cast(unsigned int, time(NULL))
+#define luai_makeseed()		cast(unsigned int, 0)
 #endif
 
 

--- a/libraries/lua-gph/lib/src/lstring.cpp
+++ b/libraries/lua-gph/lib/src/lstring.cpp
@@ -47,7 +47,7 @@ int luaS_eqlngstr (TString *a, TString *b) {
 
 
 unsigned int luaS_hash (const char *str, size_t l, unsigned int seed) {
-  unsigned int h = seed ^ cast(unsigned int, l);
+  unsigned int h = cast(unsigned int, l);
   size_t step = (l >> LUAI_HASHLIMIT) + 1;
   for (; l >= step; l -= step)
     h ^= ((h<<5) + (h>>2) + cast_byte(str[l - 1]));

--- a/libraries/lua-gph/lib/src/ltable.cpp
+++ b/libraries/lua-gph/lib/src/ltable.cpp
@@ -200,6 +200,12 @@ int luaH_next (lua_State *L, Table *t, StkId key) {
     }
   }
   for (i -= t->sizearray; cast_int(i) < sizenode(t); i++) {  /* hash part */
+    /*check table key type, only integer, string available.
+    * but the code below only passed the invalid key types
+    * lua developer maynot get any info about this rule
+    * recommend using lua_error method instead. */
+    if (!ttisstring(gkey(gnode(t, i))) && !ttisinteger(gkey(gnode(t, i))))continue;
+    
     if (!ttisnil(gval(gnode(t, i)))) {  /* a non-nil value? */
       setobj2s(L, key, gkey(gnode(t, i)));
       setobj2s(L, key+1, gval(gnode(t, i)));


### PR DESCRIPTION
* import_contract set temp_contract nil

1. lua_settop for contract create/revise/call evaluator

* adjust  lua_checkstack from 5000 to 1000

* fix contract_result replay type assert invalid

* contract apply result diff logs

* fix rollback

* Fix table traversal method's radom enumeration problem, add key type filter to enumerate function. (#121)

* adjust LUAI_HASHLIMIT to 5

* fix nft asset lock not defined in derived reflection

Co-authored-by: ck <ck@ckdeMacBook-Pro.local>
Co-authored-by: Cocos-BCX <unitedlabs@hotmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cocos-bcx/cocos-mainnet/124)
<!-- Reviewable:end -->
